### PR TITLE
Performance fix for Rand<T>(IEnumerable<T> items) where items is actually an array.

### DIFF
--- a/Faker.Net/Extensions/EnumerableExtensions.cs
+++ b/Faker.Net/Extensions/EnumerableExtensions.cs
@@ -14,7 +14,11 @@ namespace Faker.Extensions
 
         public static T Rand<T>(this T[] items)
         {
-            return items[FakerRandom.Rand.Next(items.Length - 1)];
+            if (items.Length == 0)
+            {
+                throw new ArgumentException("array is empty");
+            }
+            return items[FakerRandom.Rand.Next(items.Length)];
         }
 
         public static T Rand<T>(this IEnumerable<T> items)

--- a/Faker.Net/Extensions/EnumerableExtensions.cs
+++ b/Faker.Net/Extensions/EnumerableExtensions.cs
@@ -11,7 +11,12 @@ namespace Faker.Extensions
 			return items.Select(i => i.ToString())
 						.Aggregate((acc, next) => string.Concat(acc, separator, next));
 		}
-		
+
+        public static T Rand<T>(this T[] items)
+        {
+            return items[FakerRandom.Rand.Next(items.Length - 1)];
+        }
+
         public static T Rand<T>(this IEnumerable<T> items)
         {
             IList<T> list;


### PR DESCRIPTION
Added extension method to get random entry from an array of T in order to avoid creating a new list for every time the Rand(IEnumerable<T> items) is called. This is a performance fix.
